### PR TITLE
Added open.fm and eskago.pl support

### DIFF
--- a/data/common/options/sites.json
+++ b/data/common/options/sites.json
@@ -63,6 +63,14 @@
         "album": "yes",
         "artwork": "no"
     },
+    "eskago.pl": {
+        "url": "http://www.eskago.pl",
+        "artist": "yes",
+        "title": "yes",
+        "duration": "no",
+        "album": "no",
+        "artwork": "yes"
+    },
     "hypem.com": {
         "url": "http://hypem.com",
         "artist": "yes",
@@ -133,6 +141,14 @@
         "title": "yes",
         "duration": "no",
         "album": "no",
+        "artwork": "yes"
+    },
+    "open.fm": {
+        "url": "http://open.fm",
+        "artist": "yes",
+        "title": "yes",
+        "duration": "no",
+        "album": "yes",
         "artwork": "yes"
     },
     "pandora.com": {

--- a/data/common/websites-support/websites/eskago.js
+++ b/data/common/websites-support/websites/eskago.js
@@ -1,0 +1,18 @@
+const EskaGoTrackListener = function() {};
+EskaGoTrackListener.prototype = new Common.WebsiteTrackListener();
+
+EskaGoTrackListener.prototype.isPlaying = function() {
+    return $('#radio-controller > .wrap > a').attr('class') == "playButton pause";
+};
+
+EskaGoTrackListener.prototype.scrapPlayData = function() {
+    this.artistName = $('.playlist_small > strong').text();
+    this.trackName  = $('.playlist_small > span').text();
+    return true;
+};
+
+EskaGoTrackListener.prototype.scrapAlbumArt = function() {
+    return $('.playlist_small > img').attr('src');
+};
+
+Common.runTrackListenerInterval(new EskaGoTrackListener());

--- a/data/common/websites-support/websites/openfm.js
+++ b/data/common/websites-support/websites/openfm.js
@@ -1,0 +1,22 @@
+const OpenFMTrackListener = function() {};
+OpenFMTrackListener.prototype = new Common.WebsiteTrackListener();
+
+OpenFMTrackListener.prototype.isPlaying = function() {
+    return $('.controls-con > input').attr('class') == "active stop-btn";
+};
+
+OpenFMTrackListener.prototype.scrapPlayData = function() {
+    this.artistName = $('#station-view > .station-details > h3').text();
+    this.trackName = $('#station-view > .station-details > h2').text();
+    return true;
+};
+
+OpenFMTrackListener.prototype.scrapAlbumName = function() {
+    return $('#station-view > .station-details > h4').text();
+};
+
+OpenFMTrackListener.prototype.scrapAlbumArt = function() {
+    return "http://open.fm" + $('#station-view > .img-holder > img').attr('src');
+};
+
+Common.runTrackListenerInterval(new OpenFMTrackListener());

--- a/index.js
+++ b/index.js
@@ -139,6 +139,8 @@ createMusicWebsiteWorker('*.play.baidu.com', 'playbaidu.js', 'top');
 createMusicWebsiteWorker('*.player.kuwo.cn', 'kuwo.js', 'top');
 createMusicWebsiteWorker('*.y.qq.com', 'qq.js', 'top');
 createMusicWebsiteWorker(/.*xiami.com\/play.*/, 'xiami.js', 'top');
+createMusicWebsiteWorker(/.*open.fm.*/, 'openfm.js', 'top');
+createMusicWebsiteWorker(/.*www.eskago.pl\/radio.*/, 'eskago.js', 'top');
 
 function onAttachNowPlaying(worker) {
     worker.port.on('updateNowPlaying', function(data) {


### PR DESCRIPTION
I've added support for open.fm and eskago.pl

### open.fm
* It isn't possible to add the duration of song. Open.fm only gives approximate duration. 
* If you start playing one of the radio station, it's possible to come back to open.fm from open.fm/radio/*, but I have no idea how to distinguish this two pages in script. 

### eskago.pl
* There is no information about duration of song
* CD cover is added, but there is in low resolution and not always given.